### PR TITLE
allow get_object_or_404 to receive a None value for ekey

### DIFF
--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -52,7 +52,7 @@ def decode(e):
 
     try:
         e = base64.urlsafe_b64decode(e.replace(b".", b"="))
-    except TypeError:
+    except (TypeError, AttributeError):
         raise ValueError("Failed to decrypt, invalid input.")
 
     for skey in getattr(settings, "SECRET_KEYS", [settings.SECRET_KEY]):

--- a/tests/test_ekey.py
+++ b/tests/test_ekey.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import pytest
+from django.http import Http404
+
 from encrypted_id import ekey, get_object_or_404
 from tapp.models import Foo
 
@@ -14,3 +17,10 @@ def test_ekey(db):
     foo = Foo.objects.create(text="asd")
     assert ekey(foo) == foo.ekey
     assert foo == get_object_or_404(Foo, foo.ekey)
+
+
+def test_allow_none_ekey(db):
+    assert db is db
+
+    with pytest.raises(Http404):
+        get_object_or_404(Foo, None)


### PR DESCRIPTION
In Django if a `pk=None` when calling `get_object_or_404` a `Http404` is raised, the current implementation of this function in encrypted_id raises an `AttributeError` since replace is called on `None` (instead of a string) in `decode`.

This PR allows you to call `get_object_or_404` from encryped id with a `None` value and get a proper `Http404` exception. This eases calling `get_object_or_404` in things like views and allows to use encrypted_id's version of `get_object_or_404` like Django's.