### PR TITLE
Remove base64 padding

### DIFF
--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -43,7 +43,7 @@ def encode(the_id):
         settings.SECRET_KEY[-16:]
     )
 
-    return base64.urlsafe_b64encode(cypher.encrypt(message)).replace(b"=", b".")
+    return base64.urlsafe_b64encode(cypher.encrypt(message)).replace(b"=", b"")
 
 
 def decode(e):
@@ -51,7 +51,8 @@ def decode(e):
         e = bytes(e.encode("ascii"))
 
     try:
-        e = base64.urlsafe_b64decode(e.replace(b".", b"="))
+        padding = (3 - len(e) % 3) * b"="
+        e = base64.urlsafe_b64decode(e + padding)
     except (TypeError, AttributeError):
         raise ValueError("Failed to decrypt, invalid input.")
 


### PR DESCRIPTION
> padding is useful in situations where base64 encoded strings are concatenated in such a way that the lengths of the individual sequences are lost -[Ref](http://stackoverflow.com/questions/4080988/why-does-base64-encoding-requires-padding-if-the-input-length-is-not-divisible-b)

This doesn't concern the use-case of ekey, which effectively makes the padding redundant. Hence, the padding can be removed.