### PR TITLE
Custom queryset for model manager

### DIFF
--- a/encrypted_id/models.py
+++ b/encrypted_id/models.py
@@ -17,11 +17,22 @@ class EncryptedIDManager(models.Manager):
         return get_object_or_404(self.model, *args, **kw)
 
 
+class EncryptedIDQuerySet(models.QuerySet):
+    def filter(self, *args, **kw):
+        ekey = kw.pop('ekey', None)
+        if ekey:
+            try:
+                kw['id'] = decode(ekey)
+            except ValueError:
+                return self.none()
+        return super(EncryptedIDQuerySet, self).filter(*args, **kw)
+
+
 class EncryptedIDModel(models.Model):
     class Meta:
         abstract = True
 
-    objects = EncryptedIDManager()
+    objects = EncryptedIDManager.from_queryset(EncryptedIDQuerySet)()
 
     @property
     def ekey(self):

--- a/encrypted_id/models.py
+++ b/encrypted_id/models.py
@@ -19,11 +19,12 @@ class EncryptedIDManager(models.Manager):
 
 class EncryptedIDQuerySet(models.QuerySet):
     def filter(self, *args, **kw):
-        ekey = kw.pop('ekey', None)
-        if ekey:
+        if 'ekey' in kw:
+            ekey = kw.pop('ekey')
             try:
+                assert ekey is not None
                 kw['id'] = decode(ekey)
-            except ValueError:
+            except (AssertionError, ValueError):
                 return self.none()
         return super(EncryptedIDQuerySet, self).filter(*args, **kw)
 

--- a/encrypted_id/models.py
+++ b/encrypted_id/models.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 
+from encrypted_id import EncryptedIDDecodeError
 from encrypted_id import encode, decode, get_object_or_404
 
 
@@ -24,7 +25,7 @@ class EncryptedIDQuerySet(models.QuerySet):
             try:
                 assert ekey is not None
                 kw['id'] = decode(ekey)
-            except (AssertionError, ValueError):
+            except (AssertionError, EncryptedIDDecodeError):
                 return self.none()
         return super(EncryptedIDQuerySet, self).filter(*args, **kw)
 

--- a/requirements1.10.txt
+++ b/requirements1.10.txt
@@ -1,4 +1,4 @@
-Django==1.6.11
+Django==1.10.7
 PyCrypto
 pytest
 pytest-django

--- a/requirements1.11.txt
+++ b/requirements1.11.txt
@@ -1,4 +1,4 @@
-Django==1.5.12
+Django==1.11.2
 PyCrypto
 pytest
 pytest-django

--- a/requirements1.7.txt
+++ b/requirements1.7.txt
@@ -1,5 +1,0 @@
-Django==1.7.11
-PyCrypto
-pytest
-pytest-django
-pytest-pep8

--- a/tests/tapp/views.py
+++ b/tests/tapp/views.py
@@ -1,3 +1,9 @@
-from django.shortcuts import render
+from django.views.generic import DetailView
 
-# Create your views here.
+from tapp.models import Foo
+
+
+class FooView(DetailView):
+    model = Foo
+    slug_field = 'ekey'
+    template_name = 'admin/base.html'

--- a/tests/tekey/urls.py
+++ b/tests/tekey/urls.py
@@ -16,6 +16,11 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from tapp.views import FooView
+
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^foo/(?P<slug>[0-9a-zA-Z-_]+.{0,2})/$', FooView.as_view(),
+        name='foo'),
+    # surl('/foo/<ekey:slug>/', FooView.as_view(), name='foo'),
 ]

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,0 +1,12 @@
+import pytest
+
+from encrypted_id import EncryptedIDDecodeError, decode, encode
+
+
+def test_decode():
+    with pytest.raises(EncryptedIDDecodeError):
+        decode("")                                      # strucr.error
+    with pytest.raises(EncryptedIDDecodeError):
+        decode("1")                                     # binascii.Error
+    with pytest.raises(EncryptedIDDecodeError):
+        decode(encode(0)[:-1] + b'Z')                   # crc error

--- a/tests/test_ekey.py
+++ b/tests/test_ekey.py
@@ -24,3 +24,6 @@ def test_allow_none_ekey(db):
 
     with pytest.raises(Http404):
         get_object_or_404(Foo, None)
+
+    with pytest.raises(Foo.DoesNotExist):
+        Foo.objects.get(ekey=None)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from tapp.models import Foo, Foo2
+from django.shortcuts import get_list_or_404, get_object_or_404
 from django.http import Http404
 import pytest
 
@@ -16,11 +17,21 @@ def test_model(db):
     assert foo.ekey
     assert foo == Foo.objects.get_by_ekey(foo.ekey)
     assert foo == Foo.objects.get_by_ekey_or_404(foo.ekey)
+    assert foo == Foo.objects.get(ekey=foo.ekey)
+    assert foo == Foo.objects.filter(ekey=foo.ekey).get()
 
     foo = Foo2.objects.create(text="hello")
     assert foo.ekey
     assert foo == Foo2.objects.get_by_ekey(foo.ekey)
     assert foo == Foo2.objects.get_by_ekey_or_404(foo.ekey)
+    assert foo == Foo2.objects.get(ekey=foo.ekey)
+    assert foo == Foo2.objects.filter(ekey=foo.ekey).get()
 
     with pytest.raises(Http404):
         Foo.objects.get_by_ekey_or_404("123123")
+
+    with pytest.raises(Http404):
+        get_list_or_404(Foo, ekey="123123")
+
+    with pytest.raises(Http404):
+        get_object_or_404(Foo, ekey="123123")

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.core.urlresolvers import reverse
+from django.test import Client
+
+from tapp.models import Foo
+
+
+def test_view(db):
+    assert db is db
+
+    client = Client()
+
+    foo = Foo.objects.create(text="hello")
+    url = reverse("foo", args=(foo.ekey,))
+    response = client.get(url)
+    response_object = response.context["object"]
+    assert response_object == foo

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
 envlist =
-    py27-django15,
-    py27-django16,
-    py27-django17,
     py27-django18,
     py27-django19,
+    py27-django110,
+    py27-django111,
     py35-django18,
-    py35-django19
+    py35-django19,
+    py35-django110,
+    py35-django111
 
 
 [testenv]
@@ -15,33 +16,18 @@ changedir = tests
 commands =
     py.test --ds tekey.settings --pep8
 
-[django15]
-deps = -rrequirements1.5.txt
-
-[django16]
-deps = -rrequirements1.6.txt
-
-[django17]
-deps = -rrequirements1.7.txt
-
 [django18]
 deps = -rrequirements1.8.txt
 
 [django19]
 deps = -rrequirements1.9.txt
 
+[django110]
+deps = -rrequirements1.10.txt
 
-[testenv:py27-django15]
-basepython = python2.7
-deps = {[django15]deps}
+[django111]
+deps = -rrequirements1.11.txt
 
-[testenv:py27-django16]
-basepython = python2.7
-deps = {[django16]deps}
-
-[testenv:py27-django17]
-basepython = python2.7
-deps = {[django17]deps}
 
 [testenv:py27-django18]
 basepython = python2.7
@@ -51,6 +37,14 @@ deps = {[django18]deps}
 basepython = python2.7
 deps = {[django19]deps}
 
+[testenv:py27-django110]
+basepython = python2.7
+deps = {[django110]deps}
+
+[testenv:py27-django111]
+basepython = python2.7
+deps = {[django111]deps}
+
 [testenv:py35-django18]
 basepython = python3.5
 deps = {[django18]deps}
@@ -58,3 +52,11 @@ deps = {[django18]deps}
 [testenv:py35-django19]
 basepython = python3.5
 deps = {[django19]deps}
+
+[testenv:py35-django110]
+basepython = python3.5
+deps = {[django110]deps}
+
+[testenv:py35-django111]
+basepython = python3.5
+deps = {[django111]deps}


### PR DESCRIPTION
Hello, Amit! Hello, everyone!

The main goal of this PR is to make encrypted ids to be compatible with Django's generic views.

You can see how it works in `tests/tapp/views.py` (and also see `tests/tekey/urls.py`). The `ekey` property processed as `slug` field there.

As side effect it is possible now to use regular `get` method to get object by ekey
```python
foo = Foo.objects.get(ekey='ICz6n5TnVwk1NLLu6W_V7Q')
```
And also to use Django's shortcuts like `get_object_or_404`
```python
from django.shortcuts import get_object_or_404

foo = get_object_or_404(Foo, ekey='ICz6n5TnVwk1NLLu6W_V7Q')
```

But I had to drop support for old Django versions because of lack of `from_queryset` class method in the Model Manager.

Also I do some improvements for exceptions processing during `decode` and implement special exception class `EncryptedIDDecodeError`.

Some tests was added for this feature. Django 1.10 and 1.11 support for tests was added too.

Regards!