### PR TITLE
Return ekey in unicode format instead of bytes

### DIFF
--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -48,7 +48,8 @@ def encode(the_id):
         settings.SECRET_KEY[-16:]
     )
 
-    return base64.urlsafe_b64encode(cypher.encrypt(message)).replace(b"=", b"")
+    eid = base64.urlsafe_b64encode(cypher.encrypt(message)).replace(b"=", b"")
+    return eid.decode('utf-8')
 
 
 def decode(e):

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -9,4 +9,4 @@ def test_decode():
     with pytest.raises(EncryptedIDDecodeError):
         decode("1")                                     # binascii.Error
     with pytest.raises(EncryptedIDDecodeError):
-        decode(encode(0)[:-1] + b'Z')                   # crc error
+        decode(encode(0)[:-1] + 'Z')                    # crc error


### PR DESCRIPTION
Python 2 -> now returns `unicode` instead of `str`
Python 3 -> now returns `str` instead of `bytes`