### PR TITLE
fix: int to bytes conversion

### DIFF
--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -39,7 +39,7 @@ class EncryptedIDDecodeError(Exception):
 def encode(the_id, sub_key):
     assert 0 <= the_id < 2 ** 64
 
-    crc = binascii.crc32(struct.pack("<I", the_id)) & 0xffffffff
+    crc = binascii.crc32(struct.pack("<Q", the_id)) & 0xffffffff
 
     message = struct.pack(b"<IQxxxx", crc, the_id)
     assert len(message) == 16
@@ -76,7 +76,7 @@ def decode(e, sub_key):
             raise EncryptedIDDecodeError()
 
         try:
-            if crc != binascii.crc32(struct.pack("<I", the_id)) & 0xffffffff:
+            if crc != binascii.crc32(struct.pack("<Q", the_id)) & 0xffffffff:
                 continue
         except (MemoryError, OverflowError):
             raise EncryptedIDDecodeError()

--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -39,7 +39,7 @@ class EncryptedIDDecodeError(Exception):
 def encode(the_id, sub_key):
     assert 0 <= the_id < 2 ** 64
 
-    crc = binascii.crc32(bytes(the_id)) & 0xffffffff
+    crc = binascii.crc32(struct.pack("<I", the_id))
 
     message = struct.pack(b"<IQxxxx", crc, the_id)
     assert len(message) == 16
@@ -76,7 +76,7 @@ def decode(e, sub_key):
             raise EncryptedIDDecodeError()
 
         try:
-            if crc != binascii.crc32(bytes(the_id)) & 0xffffffff:
+            if crc != binascii.crc32(struct.pack("<I", the_id)):
                 continue
         except (MemoryError, OverflowError):
             raise EncryptedIDDecodeError()

--- a/encrypted_id/__init__.py
+++ b/encrypted_id/__init__.py
@@ -39,7 +39,7 @@ class EncryptedIDDecodeError(Exception):
 def encode(the_id, sub_key):
     assert 0 <= the_id < 2 ** 64
 
-    crc = binascii.crc32(struct.pack("<I", the_id))
+    crc = binascii.crc32(struct.pack("<I", the_id)) & 0xffffffff
 
     message = struct.pack(b"<IQxxxx", crc, the_id)
     assert len(message) == 16
@@ -76,7 +76,7 @@ def decode(e, sub_key):
             raise EncryptedIDDecodeError()
 
         try:
-            if crc != binascii.crc32(struct.pack("<I", the_id)):
+            if crc != binascii.crc32(struct.pack("<I", the_id)) & 0xffffffff:
                 continue
         except (MemoryError, OverflowError):
             raise EncryptedIDDecodeError()


### PR DESCRIPTION
Because
```
In [11]: bytes(2)
Out[11]: b'\x00\x00'

In [14]: struct.pack('<I', 2)
Out[14]: b'\x02\x00\x00\x00'
```